### PR TITLE
Use `-std=gnu89` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -w
+CFLAGS = -std=gnu89 -w
 EXECS = uwu
 
 all: $(EXECS)


### PR DESCRIPTION
Add `-std=gnu89` to `CFLAGS` so the old K&R‑style code compiles without any changes.